### PR TITLE
TypeScript, scss, and less syntax support

### DIFF
--- a/syntax/svelte.vim
+++ b/syntax/svelte.vim
@@ -58,7 +58,8 @@ highlight def link svelteConditional Conditional
 highlight def link svelteKeyword Keyword
 highlight def link svelteRepeat Repeat
 
-" Taken from vim-vue
+" Taken from vim-vue:
+" https://github.com/posva/vim-vue/blob/c424294e769b26659176065f9713c395731f7b3a/syntax/vue.vim#L20-L74
 " Get the pattern for a HTML {name} attribute with {value}.
 function! s:attr(name, value)
   return a:name . '=\("\|''\)[^\1]*' . a:value . '[^\1]*\1'
@@ -81,8 +82,12 @@ function! s:should_register(language, start_pattern)
   return 1
 endfunction
 
+" If there is desire to support more preprocessors, borrow from the vim-vue
+" syntax configuration.
 let s:languages = [
       \ {'name': 'typescript', 'tag': 'script', 'attr_pattern': '\%(lang=\("\|''\)[^\1]*\(ts\|typescript\)[^\1]*\1\|ts\)'},
+      \ {'name': 'less', 'tag': 'style'},
+      \ {'name': 'scss', 'tag': 'style'},
       \ ]
 
 for s:language in s:languages
@@ -105,5 +110,7 @@ syn region svelteSurroundingTag contained start=+<\(script\|style\|template\)+ e
 syn keyword htmlSpecialTagName contained template
 syn keyword htmlArg contained scoped ts
 syn match htmlArg "[@v:][-:.0-9_a-z]*\>" contained
+
+syntax sync fromstart
 
 let b:current_syntax = "svelte"

--- a/syntax/svelte.vim
+++ b/syntax/svelte.vim
@@ -58,8 +58,10 @@ highlight def link svelteConditional Conditional
 highlight def link svelteKeyword Keyword
 highlight def link svelteRepeat Repeat
 
-" Taken from vim-vue:
+" -----------------------------------------------------------------------------
+" Everything below forked from vim-vue:
 " https://github.com/posva/vim-vue/blob/c424294e769b26659176065f9713c395731f7b3a/syntax/vue.vim#L20-L74
+" -----------------------------------------------------------------------------
 " Get the pattern for a HTML {name} attribute with {value}.
 function! s:attr(name, value)
   return a:name . '=\("\|''\)[^\1]*' . a:value . '[^\1]*\1'
@@ -112,5 +114,9 @@ syn keyword htmlArg contained scoped ts
 syn match htmlArg "[@v:][-:.0-9_a-z]*\>" contained
 
 syntax sync fromstart
+" -----------------------------------------------------------------------------
+" Everything above forked from vim-vue:
+" https://github.com/posva/vim-vue/blob/c424294e769b26659176065f9713c395731f7b3a/syntax/vue.vim#L20-L74
+" -----------------------------------------------------------------------------
 
 let b:current_syntax = "svelte"

--- a/syntax/svelte.vim
+++ b/syntax/svelte.vim
@@ -32,27 +32,27 @@ syntax keyword svelteKeyword slot contained containedin=htmlTag
 
 " According to vim-jsx, you can let jsBlock take care of ending the region.
 "   https://github.com/mxw/vim-jsx/blob/master/after/syntax/jsx.vim
-syntax region svelteExpression start="{" end="" contains=jsBlock,javascriptBlock containedin=htmlString,htmlTag,htmlArg,htmlValue,htmlH1,htmlH2,htmlH3,htmlH4,htmlH5,htmlH6,htmlHead,htmlTitle,htmlBoldItalicUnderline,htmlUnderlineBold,htmlUnderlineItalicBold,htmlUnderlineBoldItalic,htmlItalicUnderline,htmlItalicBold,htmlItalicBoldUnderline,htmlItalicUnderlineBold,htmlLink,htmlLeadingSpace,htmlBold,htmlBoldUnderline,htmlBoldItalic,htmlBoldUnderlineItalic,htmlUnderline,htmlUnderlineItalic,htmlItalic,htmlStrike,javaScript
+syntax region svelteExpression start="{" end="" contains=jsBlock,javascriptBlock,typescriptBlock containedin=htmlString,htmlTag,htmlArg,htmlValue,htmlH1,htmlH2,htmlH3,htmlH4,htmlH5,htmlH6,htmlHead,htmlTitle,htmlBoldItalicUnderline,htmlUnderlineBold,htmlUnderlineItalicBold,htmlUnderlineBoldItalic,htmlItalicUnderline,htmlItalicBold,htmlItalicBoldUnderline,htmlItalicUnderlineBold,htmlLink,htmlLeadingSpace,htmlBold,htmlBoldUnderline,htmlBoldItalic,htmlBoldUnderlineItalic,htmlUnderline,htmlUnderlineItalic,htmlItalic,htmlStrike,javaScript
 
 " Block conditionals.
-syntax match svelteConditional "#if" contained containedin=jsBlock,javascriptBlock
-syntax match svelteConditional "/if" contained containedin=jsBlock,javascriptBlock
-syntax match svelteConditional ":else if" contained containedin=jsBlock,javascriptBlock
-syntax match svelteConditional ":else" contained containedin=jsBlock,javascriptBlock
+syntax match svelteConditional "#if" contained containedin=jsBlock,javascriptBlock,typescriptBlock
+syntax match svelteConditional "/if" contained containedin=jsBlock,javascriptBlock,typescriptBlock
+syntax match svelteConditional ":else if" contained containedin=jsBlock,javascriptBlock,typescriptBlock
+syntax match svelteConditional ":else" contained containedin=jsBlock,javascriptBlock,typescriptBlock
 
 " Block keywords.
-syntax match svelteKeyword "#await" contained containedin=jsBlock,javascriptBlock
-syntax match svelteKeyword "/await" contained containedin=jsBlock,javascriptBlock
-syntax match svelteKeyword ":catch" contained containedin=jsBlock,javascriptBlock
-syntax match svelteKeyword ":then" contained containedin=jsBlock,javascriptBlock
+syntax match svelteKeyword "#await" contained containedin=jsBlock,javascriptBlock,typescriptBlock
+syntax match svelteKeyword "/await" contained containedin=jsBlock,javascriptBlock,typescriptBlock
+syntax match svelteKeyword ":catch" contained containedin=jsBlock,javascriptBlock,typescriptBlock
+syntax match svelteKeyword ":then" contained containedin=jsBlock,javascriptBlock,typescriptBlock
 
 " Inline keywords.
-syntax match svelteKeyword "@html" contained containedin=jsBlock,javascriptBlock
-syntax match svelteKeyword "@debug" contained containedin=jsBlock,javascriptBlock
+syntax match svelteKeyword "@html" contained containedin=jsBlock,javascriptBlock,typescriptBlock
+syntax match svelteKeyword "@debug" contained containedin=jsBlock,javascriptBlock,typescriptBlock
 
 " Repeat functions.
-syntax match svelteRepeat "#each" contained containedin=jsBlock,javascriptBlock
-syntax match svelteRepeat "/each" contained containedin=jsBlock,javascriptBlock
+syntax match svelteRepeat "#each" contained containedin=jsBlock,javascriptBlock,typescriptBlock
+syntax match svelteRepeat "/each" contained containedin=jsBlock,javascriptBlock,typescriptBlock
 
 highlight def link svelteConditional Conditional
 highlight def link svelteKeyword Keyword

--- a/syntax/svelte.vim
+++ b/syntax/svelte.vim
@@ -32,27 +32,27 @@ syntax keyword svelteKeyword slot contained containedin=htmlTag
 
 " According to vim-jsx, you can let jsBlock take care of ending the region.
 "   https://github.com/mxw/vim-jsx/blob/master/after/syntax/jsx.vim
-syntax region svelteExpression start="{" end="" contains=jsBlock,javascriptBlock,typescriptBlock containedin=htmlString,htmlTag,htmlArg,htmlValue,htmlH1,htmlH2,htmlH3,htmlH4,htmlH5,htmlH6,htmlHead,htmlTitle,htmlBoldItalicUnderline,htmlUnderlineBold,htmlUnderlineItalicBold,htmlUnderlineBoldItalic,htmlItalicUnderline,htmlItalicBold,htmlItalicBoldUnderline,htmlItalicUnderlineBold,htmlLink,htmlLeadingSpace,htmlBold,htmlBoldUnderline,htmlBoldItalic,htmlBoldUnderlineItalic,htmlUnderline,htmlUnderlineItalic,htmlItalic,htmlStrike,javaScript
+syntax region svelteExpression start="{" end="" contains=jsBlock,javascriptBlock containedin=htmlString,htmlTag,htmlArg,htmlValue,htmlH1,htmlH2,htmlH3,htmlH4,htmlH5,htmlH6,htmlHead,htmlTitle,htmlBoldItalicUnderline,htmlUnderlineBold,htmlUnderlineItalicBold,htmlUnderlineBoldItalic,htmlItalicUnderline,htmlItalicBold,htmlItalicBoldUnderline,htmlItalicUnderlineBold,htmlLink,htmlLeadingSpace,htmlBold,htmlBoldUnderline,htmlBoldItalic,htmlBoldUnderlineItalic,htmlUnderline,htmlUnderlineItalic,htmlItalic,htmlStrike,javaScript
 
 " Block conditionals.
-syntax match svelteConditional "#if" contained containedin=jsBlock,javascriptBlock,typescriptBlock
-syntax match svelteConditional "/if" contained containedin=jsBlock,javascriptBlock,typescriptBlock
-syntax match svelteConditional ":else if" contained containedin=jsBlock,javascriptBlock,typescriptBlock
-syntax match svelteConditional ":else" contained containedin=jsBlock,javascriptBlock,typescriptBlock
+syntax match svelteConditional "#if" contained containedin=jsBlock,javascriptBlock
+syntax match svelteConditional "/if" contained containedin=jsBlock,javascriptBlock
+syntax match svelteConditional ":else if" contained containedin=jsBlock,javascriptBlock
+syntax match svelteConditional ":else" contained containedin=jsBlock,javascriptBlock
 
 " Block keywords.
-syntax match svelteKeyword "#await" contained containedin=jsBlock,javascriptBlock,typescriptBlock
-syntax match svelteKeyword "/await" contained containedin=jsBlock,javascriptBlock,typescriptBlock
-syntax match svelteKeyword ":catch" contained containedin=jsBlock,javascriptBlock,typescriptBlock
-syntax match svelteKeyword ":then" contained containedin=jsBlock,javascriptBlock,typescriptBlock
+syntax match svelteKeyword "#await" contained containedin=jsBlock,javascriptBlock
+syntax match svelteKeyword "/await" contained containedin=jsBlock,javascriptBlock
+syntax match svelteKeyword ":catch" contained containedin=jsBlock,javascriptBlock
+syntax match svelteKeyword ":then" contained containedin=jsBlock,javascriptBlock
 
 " Inline keywords.
-syntax match svelteKeyword "@html" contained containedin=jsBlock,javascriptBlock,typescriptBlock
-syntax match svelteKeyword "@debug" contained containedin=jsBlock,javascriptBlock,typescriptBlock
+syntax match svelteKeyword "@html" contained containedin=jsBlock,javascriptBlock
+syntax match svelteKeyword "@debug" contained containedin=jsBlock,javascriptBlock
 
 " Repeat functions.
-syntax match svelteRepeat "#each" contained containedin=jsBlock,javascriptBlock,typescriptBlock
-syntax match svelteRepeat "/each" contained containedin=jsBlock,javascriptBlock,typescriptBlock
+syntax match svelteRepeat "#each" contained containedin=jsBlock,javascriptBlock
+syntax match svelteRepeat "/each" contained containedin=jsBlock,javascriptBlock
 
 highlight def link svelteConditional Conditional
 highlight def link svelteKeyword Keyword


### PR DESCRIPTION
Svelte is making a [ton of progress](https://github.com/sveltejs/language-tools/issues/83) in setting up tooling to officially support some preprocessors, so I figure it may be time to consider adding that syntax support here.

I'll probably also start looking into the indentation file (not perfect right now), but the syntax seems good to me right now.