### PR TITLE
(bug) language aliasing

### DIFF
--- a/syntax/svelte.vim
+++ b/syntax/svelte.vim
@@ -72,13 +72,14 @@ highlight def link svelteRepeat Repeat
 " Vim and it is enabled for the Svelte plugin.
 function! s:enabled(language)
   " Check whether a syntax file for {language} exists
-  if empty(globpath(&runtimepath, 'syntax/' . a:language . '.vim'))
+  let s:syntax_name = get(a:language, 'as', a:language.name)
+  if empty(globpath(&runtimepath, 'syntax/' . s:syntax_name . '.vim'))
     return 0
   endif
 
   " If g:svelte_preprocessors is set, check for it there, otherwise return 0.
   if exists('g:svelte_preprocessors') && type(g:svelte_preprocessors) == v:t_list
-    return index(g:svelte_preprocessors, a:language) != -1
+    return index(g:svelte_preprocessors, a:language.name) != -1
   else
     return 0
   endif
@@ -102,7 +103,7 @@ for s:language in s:languages
   let s:attr = '\(lang\|type\)=\("\|''\)[^\2]*' . s:language.name . '[^\2]*\2'
   let s:start = '<' . s:language.tag . '\>\_[^>]*' . s:attr . '\_[^>]*>'
 
-  if s:enabled(s:language.name)
+  if s:enabled(s:language)
     execute 'syntax include @' . s:language.name . ' syntax/' . get(s:language, 'as', s:language.name) . '.vim'
     unlet! b:current_syntax
 

--- a/syntax/svelte.vim
+++ b/syntax/svelte.vim
@@ -102,7 +102,7 @@ for s:language in s:languages
   let s:attr = '\(lang\|type\)=\("\|''\)[^\2]*' . s:language.name . '[^\2]*\2'
   let s:start = '<' . s:language.tag . '\>\_[^>]*' . s:attr . '\_[^>]*>'
 
-  if s:enabled(s:language.name)
+  if s:enabled(get(s:language.name, 'as', s:language.name))
     execute 'syntax include @' . s:language.name . ' syntax/' . get(s:language, 'as', s:language.name) . '.vim'
     unlet! b:current_syntax
 

--- a/syntax/svelte.vim
+++ b/syntax/svelte.vim
@@ -94,7 +94,7 @@ let s:languages = [
       \ ]
 
 " Add global tag definitions to our defaults.
-if exists('g:svelte_preprocessor_tags') && type('g:svelte_preprocessor_tags') == v:t_list
+if exists('g:svelte_preprocessor_tags') && type(g:svelte_preprocessor_tags) == v:t_list
   let s:languages += g:svelte_preprocessor_tags
 endif
 
@@ -102,7 +102,7 @@ for s:language in s:languages
   let s:attr = '\(lang\|type\)=\("\|''\)[^\2]*' . s:language.name . '[^\2]*\2'
   let s:start = '<' . s:language.tag . '\>\_[^>]*' . s:attr . '\_[^>]*>'
 
-  if s:enabled(get(s:language.name, 'as', s:language.name))
+  if s:enabled(s:language.name)
     execute 'syntax include @' . s:language.name . ' syntax/' . get(s:language, 'as', s:language.name) . '.vim'
     unlet! b:current_syntax
 


### PR DESCRIPTION
Hey there! Thanks for working on this plugin, it's been massively helpful to me over the last few weekends! :smile:

I noticed when following the instructions for aliasing `typescript` as `ts`, I was only ever getting javascript highlighting. It seems that the type check for `g:svelte_preprocessor_tags` is being run against a string rather than the actual variable, so the type check ends up being `1 == 3` and custom tags never get added to the language list.

I also found that the `enabled` check doesn't account for aliases, so it will fail if you don't have a syntax file with the name of the alias (e.g. using `ts` won't work unless you have a `ts.vim` in your runtime).

I run neovim, but this change seems to work in vim as well.