### PR TITLE
Fix <script lang="ts"> highlight

### DIFF
--- a/syntax/svelte.vim
+++ b/syntax/svelte.vim
@@ -31,8 +31,6 @@ syntax keyword svelteKeyword slot contained containedin=htmlTag
 "   https://github.com/mxw/vim-jsx/blob/master/after/syntax/jsx.vim
 syntax region svelteExpression start="{" end="" contains=jsBlock,javascriptBlock containedin=htmlString,htmlTag,htmlArg,htmlValue,htmlH1,htmlH2,htmlH3,htmlH4,htmlH5,htmlH6,htmlHead,htmlTitle,htmlBoldItalicUnderline,htmlUnderlineBold,htmlUnderlineItalicBold,htmlUnderlineBoldItalic,htmlItalicUnderline,htmlItalicBold,htmlItalicBoldUnderline,htmlItalicUnderlineBold,htmlLink,htmlLeadingSpace,htmlBold,htmlBoldUnderline,htmlBoldItalic,htmlBoldUnderlineItalic,htmlUnderline,htmlUnderlineItalic,htmlItalic,htmlStrike,javaScript
 
-syntax region svelteSurroundingTag contained start=+<\(script\|style\|template\)+ end=+>+ fold contains=htmlTagN,htmlString,htmlArg,htmlValue,htmlTagError,htmlEvent
-
 " Block conditionals.
 syntax match svelteConditional "#if" contained containedin=jsBlock,javascriptBlock
 syntax match svelteConditional "/if" contained containedin=jsBlock,javascriptBlock
@@ -112,6 +110,8 @@ for s:language in s:languages
           \ 'fold'
   endif
 endfor
+
+syntax region svelteSurroundingTag contained start=+<\(script\|style\|template\)+ end=+>+ fold contains=htmlTagN,htmlString,htmlArg,htmlValue,htmlTagError,htmlEvent
 
 " Cybernetically enhanced web apps.
 let b:current_syntax = "svelte"


### PR DESCRIPTION
This PR improves highlight of script tags with `lang="ts"`.
Example of wrong highlight:

![bugged](https://user-images.githubusercontent.com/27935916/109404676-f47c0a80-7970-11eb-9816-8cd4405e7389.png)


Here's what I achieved:

![fixed](https://user-images.githubusercontent.com/27935916/109404677-f514a100-7970-11eb-8ca5-3d150a33b86a.png)


Here's what I would like to achieve, but couldn't.

![should-be](https://user-images.githubusercontent.com/27935916/109404678-f5ad3780-7970-11eb-826a-467618c98f29.png)

I've digged through vim vue, this plugin and its alternatives took inspiration from there from what I can tell.
Sadly it looks like they didn't succeed in fixing `html.vim` stuff for preprocessed languages either. :disappointed: 